### PR TITLE
WRKLDS-1295: Use brew registry for Konflux

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-4.16 AS builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.21 as builder
 WORKDIR /go/src/github.com/openshift/cli-manager
 COPY . .
 RUN make build --warn-undefined-variables
 
-FROM registry.ci.openshift.org/ocp/4.16:base-rhel9
+FROM registry.redhat.io/rhel9-2-els/rhel:9.2-1222
 COPY --from=builder /go/src/github.com/openshift/cli-manager/cli-manager /usr/bin/
 RUN dnf install -y git
 


### PR DESCRIPTION
Konflux does not support internal registries and the suggested path is to use `brew.registry.redhat.io`. This PR incorporates this requirement.
I'd like to note that `Dockerfile.ci` will continue using internal registries and CI jobs will be run along this path. `Dockerfile` which is used by Konflux pipeline will use `brew.registry.redhat.io`. That means, there might be a slight difference with regards to base images between CI and Konflux. However, there might not be any alternative to also overcome this discrepancy. 