### PR TITLE
WRKLDS-1295: Copy git binary from builder image instead installing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN make build --warn-undefined-variables
 
 FROM registry.redhat.io/rhel9-2-els/rhel:9.2-1222
 COPY --from=builder /go/src/github.com/openshift/cli-manager/cli-manager /usr/bin/
-RUN dnf install -y git
+COPY --from=builder /usr/bin/git /usr/bin/git
 
 LABEL io.k8s.display-name="CLI Manager Command" \
       io.k8s.description="OpenShift is a platform for developing, building, and deploying containerized applications." \

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -5,7 +5,7 @@ RUN make build --warn-undefined-variables
 
 FROM registry.ci.openshift.org/ocp/4.16:base-rhel9
 COPY --from=builder /go/src/github.com/openshift/cli-manager/cli-manager-testing /usr/bin/cli-manager
-RUN dnf install -y git
+COPY --from=builder /usr/bin/git /usr/bin/git
 
 LABEL io.k8s.display-name="CLI Manager Command" \
       io.k8s.description="OpenShift is a platform for developing, building, and deploying containerized applications." \


### PR DESCRIPTION
The image `registry.redhat.io/rhel9-2-els/rhel:9.2-1222` we are now using to integrate with Konflux disables the RPM repositories. Moreover, Konflux does not explicitly enable repositories currently. We can wait the enablement of those repositories to install `git`. However, in case we can unblock ourselves by copying this binary from builder image, this PR tries to achieve this.