### PR TITLE
NO-JIRA: Remove BASE_IMAGE_DIGESTS from tekton configurations

### DIFF
--- a/.tekton/cli-manager-pull-request.yaml
+++ b/.tekton/cli-manager-pull-request.yaml
@@ -255,8 +255,6 @@ spec:
       params:
       - name: BINARY_IMAGE
         value: $(params.output-image)
-      - name: BASE_IMAGES
-        value: $(tasks.build-container.results.BASE_IMAGES_DIGESTS)
       runAfter:
       - build-container
       taskRef:
@@ -282,8 +280,6 @@ spec:
         workspace: workspace
     - name: deprecated-base-image-check
       params:
-      - name: BASE_IMAGES_DIGESTS
-        value: $(tasks.build-container.results.BASE_IMAGES_DIGESTS)
       - name: IMAGE_URL
         value: $(tasks.build-container.results.IMAGE_URL)
       - name: IMAGE_DIGEST

--- a/.tekton/cli-manager-push.yaml
+++ b/.tekton/cli-manager-push.yaml
@@ -252,8 +252,6 @@ spec:
       params:
       - name: BINARY_IMAGE
         value: $(params.output-image)
-      - name: BASE_IMAGES
-        value: $(tasks.build-container.results.BASE_IMAGES_DIGESTS)
       runAfter:
       - build-container
       taskRef:
@@ -279,8 +277,6 @@ spec:
         workspace: workspace
     - name: deprecated-base-image-check
       params:
-      - name: BASE_IMAGES_DIGESTS
-        value: $(tasks.build-container.results.BASE_IMAGES_DIGESTS)
       - name: IMAGE_URL
         value: $(tasks.build-container.results.IMAGE_URL)
       - name: IMAGE_DIGEST


### PR DESCRIPTION
As described in https://github.com/konflux-ci/build-definitions/blob/main/task/buildah/0.2/MIGRATION.md, BASE_IMAGE_DIGESTS were removed entirely and https://github.com/openshift/cli-manager/pull/75 is failing due to this. This PR removes this parameter.