### PR TITLE
WRKLDS-1421: Add default for To and make Bin as optional

### DIFF
--- a/.tekton/cli-manager-pull-request.yaml
+++ b/.tekton/cli-manager-pull-request.yaml
@@ -8,7 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: |
-      event == "pull_request" && target_branch == "main" && (".tekton/cli-manager-pull-request".pathChanged() || "api/***".patchChanged() || "cmd/***".patchChanged() || "dependencymagnet/***".patchChanged() || "pkg/***".patchChanged() || "vendor/***".patchChanged() || "Dockerfile".patchChanged())
+      event == "pull_request" && target_branch == "main" && (".tekton/cli-manager-pull-request".pathChanged() || "api/***".pathChanged() || "cmd/***".pathChanged() || "dependencymagnet/***".pathChanged() || "pkg/***".pathChanged() || "vendor/***".pathChanged() || "Dockerfile".pathChanged())
   labels:
     appstudio.openshift.io/application: cli-manager-operator
     appstudio.openshift.io/component: cli-manager

--- a/.tekton/cli-manager-push.yaml
+++ b/.tekton/cli-manager-push.yaml
@@ -7,7 +7,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: |
-     event == "push" && target_branch == "main" && (".tekton/cli-manager-push.yaml".pathChanged() || "api/***".patchChanged() || "cmd/***".patchChanged() || "dependencymagnet/***".patchChanged() || "pkg/***".patchChanged() || "vendor/***".patchChanged() || "Dockerfile".patchChanged())
+     event == "push" && target_branch == "main" && (".tekton/cli-manager-push.yaml".pathChanged() || "api/***".pathChanged() || "cmd/***".pathChanged() || "dependencymagnet/***".pathChanged() || "pkg/***".pathChanged() || "vendor/***".pathChanged() || "Dockerfile".pathChanged())
   labels:
     appstudio.openshift.io/application: cli-manager-operator
     appstudio.openshift.io/component: cli-manager

--- a/api/v1alpha1/plugin_types.go
+++ b/api/v1alpha1/plugin_types.go
@@ -52,7 +52,8 @@ type PluginPlatform struct {
 	// Bin specifies the path to the plugin executable.
 	// The path is relative to the root of the installation folder.
 	// The binary will be linked after all FileOperations are executed.
-	// +required
+	// If not specified, the first From item in the Files is set.
+	// +optional
 	Bin string `json:"bin"`
 }
 
@@ -65,7 +66,9 @@ type FileLocation struct {
 	From string `json:"from"`
 
 	// To is the relative path within the root of the installation folder to place the file.
+	// Default is set to "." where points the default Krew directory.
 	// +required
+	// +kubebuilder:default:="."
 	To string `json:"to"`
 }
 

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -233,6 +233,10 @@ func convertKrewPlugin(plugin *v1alpha1.Plugin, client *kubernetes.Clientset, ro
 			return nil, err
 		}
 
+		if len(files) == 0 {
+			return nil, fmt.Errorf("files are not found in the given From path in image")
+		}
+
 		dest, err := os.Open(destinationFileName)
 		if err != nil {
 			return nil, err
@@ -274,6 +278,9 @@ func convertKrewPlugin(plugin *v1alpha1.Plugin, client *kubernetes.Clientset, ro
 				From: f.From,
 				To:   f.To,
 			})
+		}
+		if len(kp.Bin) == 0 {
+			kp.Bin = kp.Files[0].From
 		}
 		k.Spec.Platforms = append(k.Spec.Platforms, kp)
 	}

--- a/test/e2e/bindata/assets/01_config.openshift.io_plugins.yaml
+++ b/test/e2e/bindata/assets/01_config.openshift.io_plugins.yaml
@@ -59,6 +59,7 @@ spec:
                           Bin specifies the path to the plugin executable.
                           The path is relative to the root of the installation folder.
                           The binary will be linked after all FileOperations are executed.
+                          If not specified, the first From item in the Files is set.
                         type: string
                       files:
                         description: Files is a list of file locations within the image
@@ -74,9 +75,12 @@ spec:
                                 Directories and wildcards are not currently supported.
                               type: string
                             to:
-                              description: To is the relative path within the root of
+                              description: |-
+                                To is the relative path within the root of
                                 the installation folder to place the file.
+                                Default is set to "." where points the default Krew directory.
                               type: string
+                              default: "."
                           required:
                             - from
                             - to
@@ -94,7 +98,6 @@ spec:
                           darwin/amd64, windows/amd64).
                         type: string
                     required:
-                      - bin
                       - files
                       - image
                       - platform


### PR DESCRIPTION
`To` field in `Plugin` can be defaulted to `.` where points the default location of Krew. `Bin` field is no longer required because it can be set to the value of first `From` field.