### PR TITLE
WRKLDS-1421: Prepare tekton files specific to release-4.17 branch

### DIFF
--- a/.tekton/cli-manager-4-17-pull-request.yaml
+++ b/.tekton/cli-manager-4-17-pull-request.yaml
@@ -4,15 +4,16 @@ metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/openshift/cli-manager?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: |
-     event == "push" && target_branch == "main" && (".tekton/cli-manager-push.yaml".pathChanged() || "api/***".pathChanged() || "cmd/***".pathChanged() || "dependencymagnet/***".pathChanged() || "pkg/***".pathChanged() || "vendor/***".pathChanged() || "Dockerfile".pathChanged())
+      event == "pull_request" && target_branch == "release-4.17" && (".tekton/cli-manager-4-17-pull-request.yaml".pathChanged() || "api/***".pathChanged() || "cmd/***".pathChanged() || "dependencymagnet/***".pathChanged() || "pkg/***".pathChanged() || "vendor/***".pathChanged() || "Dockerfile".pathChanged())
   labels:
-    appstudio.openshift.io/application: cli-manager-operator
-    appstudio.openshift.io/component: cli-manager
+    appstudio.openshift.io/application: cli-manager-operator-4-17
+    appstudio.openshift.io/component: cli-manager-4-17
     pipelines.appstudio.openshift.io/type: build
-  name: cli-manager-on-push
+  name: cli-manager-4-17-on-pull-request
   namespace: clio-wrklds-pipeline-tenant
 spec:
   params:
@@ -21,7 +22,9 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/clio-wrklds-pipeline-tenant/cli-manager-operator/cli-manager:{{revision}}
+    value: quay.io/redhat-user-workloads/clio-wrklds-pipeline-tenant/cli-manager-operator-4-17/cli-manager-4-17:on-pr-{{revision}}
+  - name: image-expires-after
+    value: 5d
   - name: dockerfile
     value: Dockerfile
   pipelineSpec:

--- a/.tekton/cli-manager-4-17-push.yaml
+++ b/.tekton/cli-manager-4-17-push.yaml
@@ -4,16 +4,15 @@ metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/openshift/cli-manager?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
-    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: |
-      event == "pull_request" && target_branch == "main" && (".tekton/cli-manager-pull-request.yaml".pathChanged() || "api/***".pathChanged() || "cmd/***".pathChanged() || "dependencymagnet/***".pathChanged() || "pkg/***".pathChanged() || "vendor/***".pathChanged() || "Dockerfile".pathChanged())
+     event == "push" && target_branch == "release-4.17" && (".tekton/cli-manager-4-17-push.yaml".pathChanged() || "api/***".pathChanged() || "cmd/***".pathChanged() || "dependencymagnet/***".pathChanged() || "pkg/***".pathChanged() || "vendor/***".pathChanged() || "Dockerfile".pathChanged())
   labels:
-    appstudio.openshift.io/application: cli-manager-operator
-    appstudio.openshift.io/component: cli-manager
+    appstudio.openshift.io/application: cli-manager-operator-4-17
+    appstudio.openshift.io/component: cli-manager-4-17
     pipelines.appstudio.openshift.io/type: build
-  name: cli-manager-on-pull-request
+  name: cli-manager-4-17-on-push
   namespace: clio-wrklds-pipeline-tenant
 spec:
   params:
@@ -22,9 +21,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/clio-wrklds-pipeline-tenant/cli-manager-operator/cli-manager:on-pr-{{revision}}
-  - name: image-expires-after
-    value: 5d
+    value: quay.io/redhat-user-workloads/clio-wrklds-pipeline-tenant/cli-manager-operator-4-17/cli-manager-4-17:{{revision}}
   - name: dockerfile
     value: Dockerfile
   pipelineSpec:


### PR DESCRIPTION
release-4.17 branch cut has been performed and there is no more mirroring from main branch. We can update release-4.17 branch for Konflux accordingly.