### PR TITLE
WRKLDS-1421: Change metrics port to 60000 and separate metrics service file

### DIFF
--- a/pkg/cmd/cli-manager/cli_manager.go
+++ b/pkg/cmd/cli-manager/cli_manager.go
@@ -23,7 +23,7 @@ import (
 
 const (
 	PortNumber        = 9449
-	MetricsPortNumber = 8443
+	MetricsPortNumber = 60000
 	tlsCRT            = "/etc/secrets/tls.crt"
 	tlsKey            = "/etc/secrets/tls.key"
 )
@@ -86,7 +86,7 @@ func RunCLIManager(ctx context.Context, controllerContext *controllercmd.Control
 
 	go func() {
 		if err := metricsServer.ListenAndServeTLS(tlsCRT, tlsKey); !errors.Is(err, http.ErrServerClosed) {
-			klog.Errorf("git server exited with error %s", err.Error())
+			klog.Errorf("metrics server exited with error %s", err.Error())
 		}
 	}()
 

--- a/test/e2e/bindata/assets/04_deployment.yaml
+++ b/test/e2e/bindata/assets/04_deployment.yaml
@@ -45,7 +45,7 @@ spec:
           ports:
             - containerPort: 9449
               protocol: TCP
-            - containerPort: 8443
+            - containerPort: 60000
               protocol: TCP
           volumeMounts:
             - mountPath: "/etc/secrets"

--- a/test/e2e/bindata/assets/10_servicemetrics.yaml
+++ b/test/e2e/bindata/assets/10_servicemetrics.yaml
@@ -8,15 +8,14 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
   labels:
     app: openshift-cli-manager
-  name: openshift-cli-manager
+  name: openshift-cli-manager-metrics
   namespace: openshift-cli-manager-operator
 spec:
+  clusterIP: None
   ports:
-    - name: cli-manager-port
-      port: 9449
+    - port: 60000
       protocol: TCP
-      targetPort: 9449
+      targetPort: 60000
+      name: cli-manager-metrics-port
   selector:
     app: openshift-cli-manager
-  sessionAffinity: None
-  type: ClusterIP

--- a/test/e2e/bindata/assets/11_servicemonitor.yaml
+++ b/test/e2e/bindata/assets/11_servicemonitor.yaml
@@ -17,8 +17,5 @@ spec:
         serverName: metrics.openshift-cli-manager-operator.svc
   jobLabel: component
   selector:
-    namespaceSelector:
-      matchNames:
-        - openshift-cli-manager-operator
     matchLabels:
       app: openshift-cli-manager


### PR DESCRIPTION
Change metrics port to 60000, since 8443 is being used by secureserver. 