### PR TITLE
WRKLDS-1421: Add cluster-monitoring annotation in namespace

### DIFF
--- a/test/e2e/bindata/assets/00_namespace.yaml
+++ b/test/e2e/bindata/assets/00_namespace.yaml
@@ -1,4 +1,6 @@
 apiVersion: v1
 kind: Namespace
 metadata:
+  labels:
+    openshift.io/cluster-monitoring: "true"
   name: openshift-cli-manager-operator


### PR DESCRIPTION
This is complementary of https://github.com/openshift/cli-manager-operator/pull/255 to take the new label in the CI tests of cli manager.