### PR TITLE
OCPBUGS-42800: Pass platform explicitly to extract correct one from multi arch images

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	v1 "github.com/google/go-containerregistry/pkg/v1"
 	routeclient "github.com/openshift/client-go/route/clientset/versioned/typed/route/v1"
 	"github.com/openshift/library-go/pkg/controller/factory"
 	"github.com/openshift/library-go/pkg/operator/events"
@@ -319,7 +320,10 @@ func convertKrewPlugin(plugin *v1alpha1.Plugin, client *kubernetes.Clientset, dy
 		}
 
 		// attempt to pull the image down locally
-		img, err := image.Pull(p.Image, imageAuth)
+		img, err := image.Pull(p.Image, imageAuth, &v1.Platform{
+			Architecture: fields[1],
+			OS:           fields[0],
+		})
 		if err != nil {
 			newCondition := metav1.Condition{
 				Status:  metav1.ConditionFalse,

--- a/pkg/image/extract.go
+++ b/pkg/image/extract.go
@@ -19,13 +19,17 @@ import (
 const TarballPath = "/var/run/plugins/"
 
 // Pull an image down to the local filesystem.
-func Pull(src string, auth string) (v1.Image, error) {
+func Pull(src string, auth string, platform *v1.Platform) (v1.Image, error) {
 	craneOptions := []crane.Option{}
 	if len(auth) > 0 {
 		auth := authn.FromConfig(authn.AuthConfig{
 			Auth: auth,
 		})
 		craneOptions = append(craneOptions, crane.WithAuth(auth))
+	}
+
+	if platform != nil {
+		craneOptions = append(craneOptions, crane.WithPlatform(platform))
 	}
 
 	return crane.Pull(src, craneOptions...)


### PR DESCRIPTION
In case of multi arch images, we need to explicitly specify appropriate platform architecture to reference the correct binary. This PR adds support of this.