### PR TITLE
OCPBUGS-42868: Add CABundle and ProxyURL fields to access image registries

### DIFF
--- a/api/v1alpha1/plugin_types.go
+++ b/api/v1alpha1/plugin_types.go
@@ -49,6 +49,15 @@ type PluginPlatform struct {
 	// +required
 	Files []FileLocation `json:"files"`
 
+	// CA bundle encoded in base64 that is used to access to given image registry.
+	// This should contain the PEM-encoded CA certificates.
+	// +optional
+	CABundle string `json:"caBundle,omitempty"`
+
+	// Proxy URL if the image registry can be accessible via proxy
+	// +optional
+	ProxyURL string `json:"proxyURL,omitempty"`
+
 	// Bin specifies the path to the plugin executable.
 	// The path is relative to the root of the installation folder.
 	// The binary will be linked after all FileOperations are executed.

--- a/test/e2e/bindata/assets/01_config.openshift.io_plugins.yaml
+++ b/test/e2e/bindata/assets/01_config.openshift.io_plugins.yaml
@@ -71,6 +71,11 @@ spec:
                           The binary will be linked after all FileOperations are executed.
                           If not specified, plugin name is set.
                         type: string
+                      caBundle:
+                        description: |-
+                          CA bundle encoded in base64 that is used to access to given image registry.
+                          This should contain the PEM-encoded CA certificates.
+                        type: string
                       files:
                         description: Files is a list of file locations within the image that need to be extracted.
                         type: array
@@ -102,6 +107,9 @@ spec:
                         type: string
                       platform:
                         description: Platform for the given binary (i.e. linux/amd64, darwin/amd64, windows/amd64).
+                        type: string
+                      proxyURL:
+                        description: Proxy URL if the image registry can be accessible via proxy
                         type: string
                 shortDescription:
                   description: ShortDescription of the plugin.


### PR DESCRIPTION
As stated in https://github.com/openshift/enhancements/blob/master/enhancements/oc/cli-manager.md#design-details;
```
Allow specifying certificates and CAs for image registries
Allow specifying of proxy configuration for image registries
```
In order to serve a better user experience, it is better to support ca bundles and proxy urls. This PR adds this.