### PR TITLE
NO-JIRA: Add required rpms-signature-scan task in tekton

### DIFF
--- a/.tekton/cli-manager-pull-request.yaml
+++ b/.tekton/cli-manager-pull-request.yaml
@@ -454,6 +454,31 @@ spec:
         - name: kind
           value: task
         resolver: bundles
+      workspaces:
+        - name: workspace
+          workspace: workspace
+    - name: rpms-signature-scan
+      params:
+        - name: image-url
+          value: $(tasks.build-image-index.results.IMAGE_URL)
+        - name: image-digest
+          value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      runAfter:
+        - build-image-index
+      taskRef:
+        params:
+          - name: name
+            value: rpms-signature-scan
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:7aa4d3c95e2b963e82fdda392f7cb3d61e3dab035416cf4a3a34e43cf3c9c9b8
+          - name: kind
+            value: task
+        resolver: bundles
+      when:
+        - input: $(params.skip-checks)
+          operator: in
+          values:
+            - "false"
     workspaces:
     - name: git-auth
       optional: true

--- a/.tekton/cli-manager-pull-request.yaml
+++ b/.tekton/cli-manager-pull-request.yaml
@@ -454,9 +454,6 @@ spec:
         - name: kind
           value: task
         resolver: bundles
-      workspaces:
-        - name: workspace
-          workspace: workspace
     - name: rpms-signature-scan
       params:
         - name: image-url

--- a/.tekton/cli-manager-push.yaml
+++ b/.tekton/cli-manager-push.yaml
@@ -452,6 +452,31 @@ spec:
             - name: kind
               value: task
           resolver: bundles
+      workspaces:
+        - name: workspace
+          workspace: workspace
+    - name: rpms-signature-scan
+      params:
+        - name: image-url
+          value: $(tasks.build-image-index.results.IMAGE_URL)
+        - name: image-digest
+          value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      runAfter:
+        - build-image-index
+      taskRef:
+        params:
+          - name: name
+            value: rpms-signature-scan
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:7aa4d3c95e2b963e82fdda392f7cb3d61e3dab035416cf4a3a34e43cf3c9c9b8
+          - name: kind
+            value: task
+        resolver: bundles
+      when:
+        - input: $(params.skip-checks)
+          operator: in
+          values:
+            - "false"
     workspaces:
     - name: git-auth
       optional: true

--- a/.tekton/cli-manager-push.yaml
+++ b/.tekton/cli-manager-push.yaml
@@ -452,9 +452,6 @@ spec:
             - name: kind
               value: task
           resolver: bundles
-      workspaces:
-        - name: workspace
-          workspace: workspace
     - name: rpms-signature-scan
       params:
         - name: image-url


### PR DESCRIPTION
`rpms-signature-scan` will be mandatory soon and this PR adds this.