### PR TITLE
NO-JIRA: Update rpms-signature-scan image pullspec

### DIFF
--- a/.tekton/cli-manager-main-pull-request.yaml
+++ b/.tekton/cli-manager-main-pull-request.yaml
@@ -625,7 +625,7 @@ spec:
             - name: name
               value: rpms-signature-scan
             - name: bundle
-              value: quay.io/konflux-ci/konflux-vanguard/task-rpms-signature-scan:0.2@sha256:78c8d7960c6db284356d94aaae64d1fca34fff4de6a6e20d897a088af0c81cf5
+              value: quay.io/konflux-ci/konflux-vanguard/task-rpms-signature-scan:0.2@sha256:2f3015ac7a642ea7f104d2194a8cb45921570f9539c6604ddcb5f62796f22a53
             - name: kind
               value: task
           resolver: bundles

--- a/.tekton/cli-manager-main-push.yaml
+++ b/.tekton/cli-manager-main-push.yaml
@@ -614,7 +614,7 @@ spec:
             - name: name
               value: rpms-signature-scan
             - name: bundle
-              value: quay.io/konflux-ci/konflux-vanguard/task-rpms-signature-scan:0.2@sha256:78c8d7960c6db284356d94aaae64d1fca34fff4de6a6e20d897a088af0c81cf5
+              value: quay.io/konflux-ci/konflux-vanguard/task-rpms-signature-scan:0.2@sha256:2f3015ac7a642ea7f104d2194a8cb45921570f9539c6604ddcb5f62796f22a53
             - name: kind
               value: task
           resolver: bundles


### PR DESCRIPTION
EC policies are failing due to old rpms-signature-scan image. This PR bumps it to newer version.